### PR TITLE
App Credential Sharing - Choosing Correctly

### DIFF
--- a/bin/_base.py
+++ b/bin/_base.py
@@ -86,8 +86,9 @@ class SplunkScript(object):
             # the username/password stored by the Code42 app.
             #
             # https://github.com/code42/Splunk/issues/2
-            passwords = (x for x in passwordEntities.values() if x['eai:acl']['app'] == 'code42')
-            for c in passwords:
+            passwords = {i:x for i, x in passwordEntities.items() if 'eai:acl' in x and 'app' in x['eai:acl'] \
+                                                                     and x['eai:acl']['app'] == 'code42'}
+            for i, c in passwords.items():
                 if 'username' in c and c['username']:
                     config['username'] = c['username']
                 if 'clear_password' in c and c['clear_password']:

--- a/bin/_base.py
+++ b/bin/_base.py
@@ -81,7 +81,13 @@ class SplunkScript(object):
 
             config = {}
 
-            for i, c in passwordEntities.items():
+            # The permission "Sharing for config file-only objects" adds other app's
+            # credentials to this list. We need to make sure we filter down to only
+            # the username/password stored by the Code42 app.
+            #
+            # https://github.com/code42/Splunk/issues/2
+            passwords = (x for x in passwordEntities.values() if x['eai:acl']['app'] == 'code42')
+            for c in passwords:
                 if 'username' in c and c['username']:
                     config['username'] = c['username']
                 if 'clear_password' in c and c['clear_password']:

--- a/utils/clear_credentials.py
+++ b/utils/clear_credentials.py
@@ -11,56 +11,56 @@
 
 import os
 import sys
-import httplib
-import base64 as encode
 import getpass as password
 
-from splunk.clilib import cli_common as cli
+import splunk.entity as entity
+import splunk.auth as auth
 
 SPLUNK_HOME = os.environ['SPLUNK_HOME']
 APP_CONFIG = os.path.join(SPLUNK_HOME, 'etc', 'apps', 'code42', 'local', 'app.conf')
 
 print('')
 
-config = cli.getConfStanzas('app')
-credential_keys = []
-for key, value in config.iteritems():
-    if key.startswith('credential'):
-        credential_keys.append(key)
-
-if len(credential_keys) == 0:
-    print('All Code42 credentials have already been cleared.')
-    print('')
-    sys.exit(0)
-
-for credential_key in credential_keys:
-    credentials = credential_key.split(':')
-    code42_username = credentials[2]
-    print('Clearing Splunk Code42 credentials for ' + code42_username + '.')
-
+print('This script will remove all saved credentials from the Code42 app.')
+print('You will confirm this before they are removed.')
 print('')
 
 splunk_username = raw_input('Splunk Username: ')
 splunk_password = password.getpass('Splunk Password: ')
 print('')
 
-userAndPass = encode.b64encode(splunk_username + ':' + splunk_password).decode("ascii")
-headers = { 'Authorization' : 'Basic %s' %  userAndPass }
+sessionKey = auth.getSessionKey(splunk_username, splunk_password)
 
-for credential_key in credential_keys:
-    credentials = credential_key.split(':')
-    code42_username = credentials[2]
+passwordEntities = entity.getEntities(['admin', 'passwords'], namespace='code42', owner='nobody', sessionKey=sessionKey)
 
-    conn = httplib.HTTPSConnection('localhost', 8089)
-    conn.request('DELETE', '/servicesNS/nobody/code42/storage/passwords/%3A' + code42_username + '%3A', headers=headers)
-    resp = conn.getresponse()
+# The permission "Sharing for config file-only objects" adds other app's
+# credentials to this list. We need to make sure we filter down to only
+# the username/password stored by the Code42 app.
+#
+# https://github.com/code42/Splunk/issues/2
+passwords = [(i, x) for i, x in passwordEntities.items() if x['eai:acl']['app'] == 'code42']
 
-    if resp.status == 401:
-        raise Exception('Splunk username or password is invalid, or does not have valid permission.')
-    elif resp.status != 200:
-        raise Exception('Error ' + resp.status + ' deleting user credentials.')
+if len(passwords) == 0:
+    print('All Code42 credentials have already been cleared.')
+    print('')
+    sys.exit(0)
 
-    print('Successfully cleared ' + code42_username + ' credentials.')
+for name, credential in passwords:
+    print("Found credentials username %s." % credential['username'])
+
+print('')
+confirm = raw_input('To confirm deletion(s), type "DELETE": ')
+print('')
+
+if confirm.upper() != "DELETE":
+    print('Aborting.')
+    print('')
+    sys.exit(1)
+
+for name, credential in passwords:
+    entity.deleteEntity(['admin', 'passwords'], name, namespace='code42', owner='nobody', sessionKey=sessionKey)
+
+    print('Successfully cleared ' + credential['username'] + ' credentials.')
 
 print('All Code42 credentials have been cleared.')
 print('')

--- a/utils/clear_credentials.py
+++ b/utils/clear_credentials.py
@@ -38,15 +38,16 @@ passwordEntities = entity.getEntities(['admin', 'passwords'], namespace='code42'
 # the username/password stored by the Code42 app.
 #
 # https://github.com/code42/Splunk/issues/2
-passwords = [(i, x) for i, x in passwordEntities.items() if x['eai:acl']['app'] == 'code42']
+passwords = {i:x for i, x in passwordEntities.items() if 'eai:acl' in x and 'app' in x['eai:acl'] \
+                                                         and x['eai:acl']['app'] == 'code42'}
 
 if len(passwords) == 0:
     print('All Code42 credentials have already been cleared.')
     print('')
     sys.exit(0)
 
-for name, credential in passwords:
-    print("Found credentials username %s." % credential['username'])
+for name, credential in passwords.items():
+    print('Found credentials for username "%s".' % credential['username'])
 
 print('')
 confirm = raw_input('To confirm deletion(s), type "DELETE": ')
@@ -57,10 +58,11 @@ if confirm.upper() != "DELETE":
     print('')
     sys.exit(1)
 
-for name, credential in passwords:
+for name, credential in passwords.items():
     entity.deleteEntity(['admin', 'passwords'], name, namespace='code42', owner='nobody', sessionKey=sessionKey)
 
     print('Successfully cleared ' + credential['username'] + ' credentials.')
 
+print('')
 print('All Code42 credentials have been cleared.')
 print('')


### PR DESCRIPTION
Fixes #2

This should fix the issue with apps that are configured to share credentials across other apps, and the Code42 app used to be picking any one of those credentials rather than the one specifically managed by the Code42 app itself.

Additionally, this also revises the `clear_credentials.py` script to only try and remove credentials that are a part of the Code42 app itself.