### PR TITLE
Renaming endpoint

### DIFF
--- a/bin/c42splunk/common/splunk_common.py
+++ b/bin/c42splunk/common/splunk_common.py
@@ -97,9 +97,9 @@ def _config_dict(session_key, attempt=0):
         # list all credentials
         password_entities = entity.getEntities(['admin', 'passwords'], namespace='code42',
                                                owner='nobody', sessionKey=session_key)
-        config_console_entities = entity.getEntities(['code42', 'config', 'console'], namespace='code42',
+        config_console_entities = entity.getEntities(['code42', 'config_code42', 'console'], namespace='code42',
                                                      owner='nobody', sessionKey=session_key)
-        config_script_entities = entity.getEntities(['code42', 'config', 'script'], namespace='code42',
+        config_script_entities = entity.getEntities(['code42', 'config_code42', 'script'], namespace='code42',
                                                     owner='nobody', sessionKey=session_key)
     except Exception as exception:
         raise Exception("Could not get code42 credentials from splunk. Error: %s" % (str(exception)))

--- a/default/restmap.conf
+++ b/default/restmap.conf
@@ -2,9 +2,9 @@
 
 [admin:code42]
 match = /code42
-members = config
+members = config_code42
 
-[admin_external:config]
+[admin_external:config_code42]
 handlertype = python
 handlerfile = splunk_configure.py
 handleractions = list, edit

--- a/django/code42/forms.py
+++ b/django/code42/forms.py
@@ -198,7 +198,7 @@ class SetupForm(forms.Form):
     @staticmethod
     def _get_config(service, stanza='console'):
         """Get non-credential Code42 configuration settings entity"""
-        config_endpoint = client.Collection(service, 'code42/config/%s' % stanza)
+        config_endpoint = client.Collection(service, 'code42/config_code42/%s' % stanza)
         configs = config_endpoint.list()
 
         return configs[0] if len(configs) > 0 else None
@@ -206,7 +206,7 @@ class SetupForm(forms.Form):
     @classmethod
     def _set_config(cls, service, stanza='console', **kwargs):
         """Set non-credential Code42 configuration settings entity"""
-        config_endpoint = client.Collection(service, 'code42/config/%s' % stanza)
+        config_endpoint = client.Collection(service, 'code42/config_code42/%s' % stanza)
         config_endpoint.post(**kwargs)
 
     @staticmethod


### PR DESCRIPTION
This change is required to avoid conflict with other Splunk apps, like the AWS (Splunk_TA_aws)